### PR TITLE
Converting CSS Framework to Material 2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@angular/core": "^5.1.0",
     "@angular/forms": "^5.1.0",
     "@angular/http": "^5.1.0",
+    "@angular/material": "5.2.3",
     "@angular/platform-browser": "^5.1.0",
     "@angular/platform-browser-dynamic": "^5.1.0",
     "@angular/router": "^5.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
     "zone.js": "^0.8.14"
   },
   "devDependencies": {
-    "@angular/cli": "1.5.0",
+    "@angular/cli": "^1.5.0",
     "@angular/compiler-cli": "^5.1.0",
     "@angular/language-service": "^5.1.0",
     "@types/jasmine": "~2.5.53",

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -5,6 +5,8 @@ import {JwtModule} from '@auth0/angular-jwt';
 import {HttpClientModule} from '@angular/common/http';
 import {RouterModule} from '@angular/router';
 
+import {MatChipsModule} from '@angular/material';
+
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
@@ -98,7 +100,8 @@ export function tokenGetter(): string {
     SharedModule,
     ReactiveFormsModule,
     NoopAnimationsModule,
-    NgxDatatableModule
+    NgxDatatableModule,
+    MatChipsModule
   ],
   providers: [IngestService, BrokerService, AuthService, FormBuilder, AlertService, LoaderService, FlattenService],
   bootstrap: [AppComponent]

--- a/client/src/app/submission/submission.component.html
+++ b/client/src/app/submission/submission.component.html
@@ -1,28 +1,19 @@
 <script src="submission.component.ts"></script>
 <script src="../shared/components/project/project.component.ts"></script>
-<div class="container-fluid">
+<div class="container-fluid mat-typography">
   <br/>
-
   <div class="row">
-    <div class="col-sm-10"><h1> Submission</h1></div>
-    <div class="col-sm-2">
-      <h3>
-        <span class="float-right" [ngSwitch]="submissionState">
-          <span *ngSwitchCase="'Pending'" class="badge badge-pill badge-warning">{{submissionState}}</span>
-          <span *ngSwitchCase="'Draft'" class="badge badge-pill badge-warning">{{submissionState}}</span>
-          <span *ngSwitchCase="'Validating'" class="badge badge-pill badge-info">{{submissionState}}</span>
-          <span *ngSwitchCase="'Valid'" class="badge badge-pill badge-success">{{submissionState}}</span>
-          <span *ngSwitchCase="'Invalid'" class="badge badge-pill badge-danger">{{submissionState}}</span>
-          <span *ngSwitchCase="'Submitted'" class="badge badge-pill badge-secondary">{{submissionState}}</span>
-          <span *ngSwitchCase="'Processing'" class="badge badge-pill border border-warning bg-light text-warning">{{submissionState}}</span>
-          <span *ngSwitchCase="'Cleanup'" class="badge badge-pill border border-warning bg-light text-warning">{{submissionState}}</span>
-          <span *ngSwitchCase="'Complete'" class="badge badge-pill border border-success bg-light text-success">{{submissionState}}</span>
-        </span>
-      </h3>
+    <div class="col-lg-12">
+      <div class="d-flex justify-content-between">
+        <h1 class="mat-headline">Submission</h1>
+        <mat-chip-list selectable="false">
+          <mat-basic-chip [ngClass]="getSubmissionStateChipClassName(submissionState)">{{submissionState}}</mat-basic-chip>
+        </mat-chip-list>
+      </div>
     </div>
   </div>
   <br/>
-  <h3>{{projectName}}</h3>
+  <h3 class="subheading-2">{{projectName}}</h3>
   <br/>
   <div class="row">
     <div class="col-lg-12">

--- a/client/src/app/submission/submission.component.scss
+++ b/client/src/app/submission/submission.component.scss
@@ -1,0 +1,44 @@
+/**
+ * Human Cell Atlas - Ingest UI
+ * http://ui.ingest.dev.data.humancellatlas.org
+ *
+ * Styles specific to submission component.
+ */
+
+/* 
+ * Mimic standard (non-basic) MD chip styles as a base for chips. Add additional classes to chips for styling of chips 
+ * in different states.
+ */
+.mat-basic-chip {
+  align-items: center;
+  border-radius: 24px;
+  color: #ffffff;
+  cursor: default;
+  display: inline-flex;
+  transition: box-shadow 280ms cubic-bezier(.4,0,.2,1);
+  padding: 7px 12px;
+  /* TODO applying BS naming convention for coloring chips, revisit once ingest-UI UI design is complete. Also revisit use of CSS variables. */
+  &.danger {
+    background-color: var(--danger);
+  }
+  &.info {
+    background-color: var(--info);
+  }
+  &.secondary {
+    background-color: var(--secondary);
+  }
+  &.success {
+    background-color: var(--success);
+  }
+  &.success-invert {
+    border: 1px solid var(--success);
+    color: var(--success);
+  }
+  &.warning {
+    background-color: var(--warning);
+  }
+  &.warning-invert {
+    border: 1px solid var(--warning);
+    color: var(--warning);
+  }
+}

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -10,7 +10,7 @@ import {FlattenService} from "../shared/services/flatten.service";
 @Component({
   selector: 'app-submission',
   templateUrl: './submission.component.html',
-  styleUrls: ['./submission.component.css']
+  styleUrls: ['./submission.component.scss']
 })
 export class SubmissionComponent implements OnInit {
   submissionEnvelopeId: string;
@@ -29,7 +29,7 @@ export class SubmissionComponent implements OnInit {
   activeTab: string;
 
   isSubmittable: boolean;
-  isSubmitted:boolean;
+  isSubmitted: boolean;
   submitLink: string;
 
   project: any;
@@ -37,7 +37,7 @@ export class SubmissionComponent implements OnInit {
   projectName: string;
 
   private alive: boolean;
-  private pollInterval : number;
+  private pollInterval: number;
 
   constructor(private ingestService: IngestService,
               private route: ActivatedRoute,
@@ -130,4 +130,43 @@ export class SubmissionComponent implements OnInit {
     return links && links['submit']? links['submit']['href'] : null;
   }
 
+  /**
+   * Return the CSS class name corresponding to the current submission state value, for styling the submission state
+   * chip.
+   *
+   * @param submissionState {string}
+   * @returns {string}
+   */
+  getSubmissionStateChipClassName(submissionState: string): string {
+
+    if ( submissionState === 'Pending' || submissionState === 'Draft' ) {
+      return 'warning';
+    }
+
+    if ( submissionState === 'Valid' ) {
+      return 'success';
+    }
+
+    if ( submissionState === 'Validating' ) {
+      return 'info';
+    }
+
+    if ( submissionState === 'Invalid' ) {
+      return 'danger';
+    }
+
+    if ( submissionState === 'Submitted' ) {
+      return 'secondary';
+    }
+
+    if ( submissionState === 'Processing' || submissionState === 'Cleanup' ) {
+      return 'warning-invert';
+    }
+
+    if ( submissionState === 'Complete' ) {
+      return 'success-invert';
+    }
+
+    return '';
+  }
 }

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -9,6 +9,7 @@
   <title>HCA Data Ingest</title>
   <base href="/">
   <script src="https://cdn.auth0.com/js/auth0/8.10.1/auth0.min.js"></script>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
   <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css"-->
         <!--integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">-->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.2/flatly/bootstrap.min.css" >

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -9,3 +9,6 @@ body {
 @import '~@swimlane/ngx-datatable/release/index.css';
 @import '~@swimlane/ngx-datatable/release/themes/material.css';
 @import '~@swimlane/ngx-datatable/release/assets/icons.css';
+
+// Default MD theme TODO revisit - customize once ingest-ui UI design is completed 
+@import '~@angular/material/prebuilt-themes/deeppurple-amber.css';


### PR DESCRIPTION
# Updates

1. Upgraded `@angular/cli` to 1.7.1 due to compile error (see [https://github.com/angular/angular-cli/issues/9307](https://github.com/angular/angular-cli/issues/9307)).

1. Added `@angular/material` with `npm install @angular/material --save --save-exact`.

1. Added link to externally-hosted Roboto fonts in `index.html`. (Roboto is Material Design’s default font.) We can host the font files locally rather than requesting fonts over the wire, if that is preferred. 

1. Added `mat-typography` CSS class to `submission.component.html`, which applies default Material Design header styles to all dependent header tags. We can move this class to an ancestor element once we start to skin additional components. See [https://material.angular.io/guide/typography#usage](https://material.angular.io/guide/typography#usage) for details.

1. Updated Bootstrap `col-x` classes to be `col-xs` (rather than `col-lg` and `col-sm`) as Bootstrap `col-x` classes are mobile first. 

1. Added Material Design classes to `h1` and `h3` tags. See [https://material.angular.io/guide/typography#what-is-typography-](https://material.angular.io/guide/typography#what-is-typography-) for details.

1. Converted submission state display from Bootstrap badge to Material Design chip.

# To Discuss/Questions

1. TS imports in `submission.component.html`.

1. Multiple nested `container-fluid` without corresponding `row` or `col-x` dependents.

# To Do

- [ ] Convert grid from Bootstrap to Material.

- [ ] Convert tabs from Bootstrap to Material.

- [ ] Convert metadata table from ngx-datatable to Material.