### PR TITLE
Display SubmissionErrors from Repository

### DIFF
--- a/client/src/app/shared/services/ingest.service.ts
+++ b/client/src/app/shared/services/ingest.service.ts
@@ -74,6 +74,10 @@ export class IngestService {
     return this.http.get(`${this.API_URL}/projects/${id}`);
   }
 
+  public getSubmissionErrors(submissionId): Observable<Object>{
+    return this.http.get(`${this.API_URL}/submissionEnvelopes/${submissionId}/submissionErrors`);
+  }
+
   public getSubmissionManifest(submissionId): Observable<Object>{
     return this.http.get(`${this.API_URL}/submissionEnvelopes/${submissionId}/submissionManifest`);
   }

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -18,8 +18,6 @@ export class SubmissionComponent implements OnInit {
   submissionEnvelope$: Observable<any>;
   submissionEnvelope;
   submissionState: string;
-  submissionErrors: string;
-
 
   activeTab: string;
 
@@ -37,6 +35,7 @@ export class SubmissionComponent implements OnInit {
   private pollInterval: number;
 
   manifest: Object;
+  submissionErrors: Object;
 
   constructor(
     private alertService: AlertService,
@@ -82,16 +81,21 @@ export class SubmissionComponent implements OnInit {
             this.submissionState = data['submissionState'];
             this.isSubmitted = this.isStateSubmitted(data.submissionState)
             this.submitLink = this.getLink(data, 'submit');
-            this.url = this.getLink(data, 'self')
-            let err = data['submissionErrors'] ? data['submissionErrors'][0] : null;
-            if (err){
-              this.alertService.clear();
-              this.alertService.error(err['message'],
-                `${err['errorCode']} : ${err['details']}`,
-                false, false);
-              console.log(err);
-            }
+            this.url = this.getLink(data, 'self');
           });
+
+        this.ingestService.getSubmissionErrors(this.submissionEnvelopeId)
+          .subscribe(
+            data => {
+              this.submissionErrors = data['_embedded']['submissionErrors'];
+              const err = this.submissionErrors ? this.submissionErrors[0] : null;
+              if (err){
+                this.alertService.clear();
+                this.alertService.error(err['title'], err['detail'], false, false);
+                console.log(err);
+              }
+            }
+          );
 
         this.ingestService.getSubmissionManifest(this.submissionEnvelopeId)
           .subscribe(


### PR DESCRIPTION
Display SubmissionErrors stored in the the new repository rather than as a property of the SubmissionEnvelope.

For new SubmissionError format introduced by [ingest-core: SubmissionError Repository](https://github.com/HumanCellAtlas/ingest-core/pull/72)
For [#447](https://github.com/HumanCellAtlas/ingest-central/issues/447)